### PR TITLE
fix: minutes calculated incorrectly

### DIFF
--- a/src/Support/ConverterEnum.php
+++ b/src/Support/ConverterEnum.php
@@ -5,7 +5,7 @@ namespace Binarcode\LaravelMailator\Support;
 class ConverterEnum
 {
     public const MINUTES_IN_HOUR = 60;
-    public const MINUTES_IN_DAY = 60 * 60;
+    public const MINUTES_IN_DAY = 24 * 60;
     public const MINUTES_IN_WEEK = 168 * 60;
     public const HOURS_IN_DAY = 24;
     public const HOURS_IN_WEEK = 168;


### PR DESCRIPTION
this: 

```
Scheduler::init('Some notification')
            ->......
            ->days(1)
```

will set the delay_minutes in the DB to 3600 (2.5 days) instead of 1440 (1 day)