### PR TITLE
fix: calculate afterConstrain diff in minutes

### DIFF
--- a/src/Constraints/AfterConstraint.php
+++ b/src/Constraints/AfterConstraint.php
@@ -38,13 +38,13 @@ class AfterConstraint implements SendScheduleConstraint
                 : $schedule->timestamp_target->diffInHours(now()->floorSeconds()) > $schedule->toHours();
         }
 
-        if (now()->floorSeconds()->lte($schedule->timestampTarget()->addMinutes($schedule->delay_minutes))) {
+        if (now()->floorSeconds()->lt($schedule->timestampTarget()->addMinutes($schedule->delay_minutes))) {
             return false;
         }
 
         //till ends we should have at least toDays days
         return $schedule->isOnce()
-            ? $schedule->timestamp_target->diffInHours(now()->floorSeconds()) === $schedule->delay_minutes
-            : $schedule->timestamp_target->diffInHours(now()->floorSeconds()) > $schedule->delay_minutes;
+            ? $schedule->timestamp_target->diffInMinutes(now()->floorSeconds()) >= $schedule->delay_minutes
+            : $schedule->timestamp_target->diffInMinutes(now()->floorSeconds()) > $schedule->delay_minutes;
     }
 }

--- a/tests/Feature/AfterConstraintTest.php
+++ b/tests/Feature/AfterConstraintTest.php
@@ -6,6 +6,7 @@ use Binarcode\LaravelMailator\Constraints\AfterConstraint;
 use Binarcode\LaravelMailator\Models\MailatorSchedule;
 use Binarcode\LaravelMailator\Tests\Fixtures\InvoiceReminderMailable;
 use Binarcode\LaravelMailator\Tests\TestCase;
+use Carbon\Carbon;
 use Illuminate\Support\Facades\Mail;
 
 class AfterConstraintTest extends TestCase
@@ -93,5 +94,49 @@ class AfterConstraintTest extends TestCase
         self::assertFalse(
             $can
         );
+    }
+
+    public function test_past_target_with_after_now_passed_after_constraint_minutes_bases()
+    {
+        Mail::fake();
+        Mail::assertNothingSent();
+
+        $scheduler = MailatorSchedule::init('reminder')
+            ->recipients('zoo@bar.com')
+            ->mailable(
+                (new InvoiceReminderMailable())->to('foo@bar.com')
+            )
+            ->minutes(10)
+            ->after(now());
+
+        $scheduler->save();
+
+        $this->travelTo(now()->addMinutes(5));
+
+        self::assertTrue(
+            $scheduler->fresh()->isFutureAction()
+        );
+
+        $this->travelTo(now()->addMinutes(5));
+
+        self::assertTrue(
+            app(AfterConstraint::class)
+                ->canSend(
+                    $scheduler,
+                    $scheduler->logs
+                )
+        );
+
+        $this->travelTo(now()->addMinutes(5));
+
+        //as long as we have passed the "after" minutes target this should return true
+        self::assertTrue(
+            app(AfterConstraint::class)
+                ->canSend(
+                    $scheduler,
+                    $scheduler->logs
+                )
+        );
+
     }
 }


### PR DESCRIPTION
fixes #2575

this was used on line 47:
$schedule->timestamp_target->diffInMinutes(now()->floorSeconds()) >= $schedule->delay_minutes

instead of this:
$schedule->timestamp_target->diffInMinutes(now()->floorSeconds()) === $schedule->delay_minutes

because the second option will work only if mailator will be run every minute, which will probably not happen. So, for example, if the notification should be sent 10m after a target time and when the mailator is run we are more than 20m past it i think this should return true anyway.