### PR TITLE
fix(postgresql): enforce public properties for PostgreSQL serialization

### DIFF
--- a/config/mailator.php
+++ b/config/mailator.php
@@ -63,4 +63,14 @@ return [
             Binarcode\LaravelMailator\Replacers\SampleReplacer::class,
         ],
     ],
+
+    'serialization' => [
+        /*
+        > Controls constructor property accessibility in mailable objects for PostgreSQL compatibility.
+        > When set to false, allows private/protected properties. When true, enforces
+        > public properties only to prevent PostgreSQL serialization errors caused by
+        > null bytes (\x00) in non-public properties.
+        */
+        'enforce_public_properties' => false,
+    ]
 ];

--- a/tests/Feature/AllowNonPublicPropertiesTest.php
+++ b/tests/Feature/AllowNonPublicPropertiesTest.php
@@ -12,7 +12,6 @@ use RuntimeException;
 
 class AllowNonPublicPropertiesTest extends TestCase
 {
-
     protected function setUp(): void
     {
         parent::setUp();
@@ -83,4 +82,3 @@ class AllowNonPublicPropertiesTest extends TestCase
             ->execute();
     }
 }
-

--- a/tests/Feature/AllowNonPublicPropertiesTest.php
+++ b/tests/Feature/AllowNonPublicPropertiesTest.php
@@ -1,0 +1,86 @@
+<?php
+
+namespace Binarcode\LaravelMailator\Tests\Feature;
+
+use Binarcode\LaravelMailator\Models\MailatorSchedule;
+use Binarcode\LaravelMailator\Tests\Fixtures\PrivatePropertyMailable;
+use Binarcode\LaravelMailator\Tests\Fixtures\ProtectedPropertyMailable;
+use Binarcode\LaravelMailator\Tests\Fixtures\PublicPropertyMailable;
+use Binarcode\LaravelMailator\Tests\TestCase;
+use Illuminate\Support\Facades\Mail;
+use RuntimeException;
+
+class AllowNonPublicPropertiesTest extends TestCase
+{
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        Mail::fake();
+    }
+
+    public function test_can_send_email_with_private_property(): void
+    {
+        config()->set('mailator.serialization.enforce_public_properties', false);
+
+        MailatorSchedule::init('private')
+            ->mailable(new PrivatePropertyMailable('test'))
+            ->execute();
+
+        Mail::assertSent(PrivatePropertyMailable::class);
+    }
+
+    public function test_can_not_send_email_with_private_property(): void
+    {
+        config()->set('mailator.serialization.enforce_public_properties', true);
+
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('Mailable contains non-public constructor properties which cannot be safely serialized');
+
+        MailatorSchedule::init('private')
+            ->mailable(new PrivatePropertyMailable('test'))
+            ->execute();
+    }
+
+    public function test_can_send_email_with_protected_property(): void
+    {
+        config()->set('mailator.serialization.enforce_public_properties', false);
+
+        MailatorSchedule::init('protected')
+            ->mailable(new ProtectedPropertyMailable('test'))
+            ->execute();
+
+        Mail::assertSent(ProtectedPropertyMailable::class);
+    }
+
+    public function test_can_not_send_email_with_protected_property(): void
+    {
+        config()->set('mailator.serialization.enforce_public_properties', true);
+
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('Mailable contains non-public constructor properties which cannot be safely serialized');
+
+        MailatorSchedule::init('protected')
+            ->mailable(new ProtectedPropertyMailable('test'))
+            ->execute();
+    }
+
+    public function test_can_send_email_with_public_property(): void
+    {
+        config()->set('mailator.serialization.enforce_public_properties', true);
+
+        MailatorSchedule::init('protected')
+            ->mailable(new PublicPropertyMailable('test'))
+            ->execute();
+
+        Mail::assertSent(PublicPropertyMailable::class);
+
+        config()->set('mailator.serialization.enforce_public_properties', false);
+
+        MailatorSchedule::init('protected')
+            ->mailable(new PublicPropertyMailable('test'))
+            ->execute();
+    }
+}
+

--- a/tests/Fixtures/PrivatePropertyMailable.php
+++ b/tests/Fixtures/PrivatePropertyMailable.php
@@ -1,0 +1,24 @@
+<?php
+
+
+namespace Binarcode\LaravelMailator\Tests\Fixtures;
+
+use Illuminate\Bus\Queueable;
+use Illuminate\Mail\Mailable;
+use Illuminate\Queue\SerializesModels;
+
+class PrivatePropertyMailable extends Mailable
+{
+    use Queueable;
+    use SerializesModels;
+
+    public function __construct(
+        private string $name
+    ) {
+    }
+
+    public function build()
+    {
+        return $this->view('laravel-mailator::mails.stub_invoice_reminder_view');
+    }
+}

--- a/tests/Fixtures/ProtectedPropertyMailable.php
+++ b/tests/Fixtures/ProtectedPropertyMailable.php
@@ -1,0 +1,24 @@
+<?php
+
+
+namespace Binarcode\LaravelMailator\Tests\Fixtures;
+
+use Illuminate\Bus\Queueable;
+use Illuminate\Mail\Mailable;
+use Illuminate\Queue\SerializesModels;
+
+class ProtectedPropertyMailable extends Mailable
+{
+    use Queueable;
+    use SerializesModels;
+
+    public function __construct(
+        protected string $name
+    ) {
+    }
+
+    public function build()
+    {
+        return $this->view('laravel-mailator::mails.stub_invoice_reminder_view');
+    }
+}

--- a/tests/Fixtures/PublicPropertyMailable.php
+++ b/tests/Fixtures/PublicPropertyMailable.php
@@ -1,0 +1,24 @@
+<?php
+
+
+namespace Binarcode\LaravelMailator\Tests\Fixtures;
+
+use Illuminate\Bus\Queueable;
+use Illuminate\Mail\Mailable;
+use Illuminate\Queue\SerializesModels;
+
+class PublicPropertyMailable extends Mailable
+{
+    use Queueable;
+    use SerializesModels;
+
+    public function __construct(
+        public string $name
+    ) {
+    }
+
+    public function build()
+    {
+        return $this->view('laravel-mailator::mails.stub_invoice_reminder_view');
+    }
+}


### PR DESCRIPTION
Resolves PostgreSQL serialization issues caused by null bytes (\x00) in private/protected mailable properties. Adds configuration option `enforce_public_properties` to control property accessibility in mailable objects.

Changes:
- Add `enforce_public_properties` config option (default: false)
- Add constructor property validation to ensure compliance
- Add test coverage for property validation